### PR TITLE
db/upgrade.php: Use more recordsets to handle large amounts of equella r...

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -114,13 +114,13 @@ function xmldb_equella_upgrade($oldversion) {
         foreach ($records as $resource)
         {
             preg_match($pattern, $resource->url, $matches);
-            if (empty($resource->uuid)) {
+            if (empty($resource->uuid) && !empty($matches['uuid'])) {
                 $resource->uuid = $matches['uuid'];
             }
-            if (empty($resource->version)) {
+            if (empty($resource->version) && !empty($matches['version'])) {
                 $resource->version = $matches['version'];
             }
-            if (empty($resource->path)) {
+            if (empty($resource->path) && !empty($matches['path'])) {
                 $resource->path = $matches['path'];
             }
 
@@ -141,7 +141,7 @@ function xmldb_equella_upgrade($oldversion) {
             $dbman->add_field($table, $field);
         }
 
-        $records = $DB->get_records('equella');
+        $records = $DB->get_recordset('equella');
         foreach ($records as $eq) {
             $eq->ltisalt = uniqid('', true);
             $DB->update_record("equella", $eq);
@@ -152,7 +152,7 @@ function xmldb_equella_upgrade($oldversion) {
 
     if ($oldversion < 2013080801) {
 
-        $records = $DB->get_records('equella');
+        $records = $DB->get_recordset('equella');
         foreach ($records as $eq) {
             // check if attachmentuuid field exists
             if (preg_match('/[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}/', $eq->attachmentuuid)) {


### PR DESCRIPTION
Please merge to fix:

-->mod_equella
PHP Notice: Undefined index: uuid in /var/www/moodle/mod/equella/db/upgrade.php on line 118

Notice: Undefined index: uuid in /var/www/moodle/mod/equella/db/upgrade.php on line 118
PHP Notice: Undefined index: version in /var/www/moodle/mod/equella/db/upgrade.php on line 121

Notice: Undefined index: version in /var/www/moodle/mod/equella/db/upgrade.php on line 121
PHP Notice: Undefined index: path in /var/www/moodle/mod/equella/db/upgrade.php on line 124

Notice: Undefined index: path in /var/www/moodle/mod/equella/db/upgrade.php on line 124
PHP Fatal error: Allowed memory size of 1073741824 bytes exhausted (tried to allocate 75 
bytes) in /var/www/moodle/lib/dml/pgsql_native_moodle_database.php on line 1001

Version (equella | 2012082806) and stuck in upgrade loop.
