### PR TITLE
Add DISTINCT to the SQL call to remove duplicate ID numbers

### DIFF
--- a/common/lib.php
+++ b/common/lib.php
@@ -154,7 +154,7 @@ function equella_getssotoken_api() {
  */
 function get_all_editing_roles() {
     global $DB;
-    $sql = "SELECT r.* FROM {role_capabilities} rc
+    $sql = "SELECT DISTINCT r.* FROM {role_capabilities} rc
             INNER JOIN {role} r ON rc.roleid = r.id
             WHERE capability = :capability
             AND permission = 1


### PR DESCRIPTION
This removes the following error message when debugging is turned on. We have the same role with the moodle/course:manageactivities capability in two different contexts. Adding DISTINCT removes the duplicate row.

Did you remember to make the first column something unique in your call to get_records? Duplicate value '3' found in column 'id'.

```
line 1005 of /lib/dml/mysqli_native_moodle_database.php: call to debugging()
line 162 of /mod/equella/common/lib.php: call to mysqli_native_moodle_database->get_records_sql()
line 83 of /mod/equella/settings.php: call to get_all_editing_roles()
line 89 of /lib/classes/plugininfo/mod.php: call to include()
line 35 of /admin/settings/plugins.php: call to core\plugininfo\mod->load_settings()
line 6389 of /lib/adminlib.php: call to require()
line 51 of /admin/settings.php: call to admin_get_root()
```
