### PR TITLE
Add EQUELLA views to moodle logs when using LTI

### DIFF
--- a/ltilaunch.php
+++ b/ltilaunch.php
@@ -36,6 +36,9 @@ if ($action == 'view') {
     $equella->cmid = $cmid;
     $equella->course = $course->id;
     $params = equella_lti_params($equella, $course);
+    
+    add_to_log($course->id, "equella", "view equella resource", "view.php?id=$cm->id", $equella->id, $cm->id);
+    
     echo '<html><body>';
     echo equella_lti_launch_form($equella->url, $params);
     echo '</body></html>';


### PR DESCRIPTION
When LTI authentication is enabled, viewing an EQUELLA resource set to open in a new window did not add an entry to the moodle logs. Log entry added just before the redirect (similar to view.php).
