### PR TITLE
Fix mimetype backup

### DIFF
--- a/backup/moodle2/backup_equella_stepslib.php
+++ b/backup/moodle2/backup_equella_stepslib.php
@@ -19,7 +19,7 @@ class backup_equella_activity_structure_step extends backup_activity_structure_s
     protected function define_structure() {
         $equella = new backup_nested_element('equella',
                 array('id'),
-                array('course','name','intro','introformat','timecreated','timemodified','url','popup','activation','uuid','version','path','attachmentuuid')
+                array('course','name','intro','introformat','timecreated','timemodified','url','mimetype','popup','activation','uuid','version','path','attachmentuuid','ltisalt')
         );
         $equella->set_source_table('equella', array('id' => backup::VAR_ACTIVITYID));
         $equella->annotate_files('mod_equella', 'intro', null);


### PR DESCRIPTION
The backup and restore function does not pull in the new mimetype and ltisalt database columns
I just merged from upstream as well so sorry for the all the additional commits. Just view 2e370c9 and add that change to backup/moodle2/backup_equella_stepslib.php then close this one.
