### PR TITLE
Update event listener to use Moodle Event API 2

### DIFF
--- a/db/events.php
+++ b/db/events.php
@@ -21,18 +21,13 @@
  */
 
 /* List of handlers */
-$handlers = array(
-    'mod_updated' => array(
-        'handlerfile' => '/mod/equella/lib.php',
-        'handlerfunction' => 'equella_handle_mod_updated',
-        'schedule' => 'instant',
-        'internal' => 1
-    ),
-
-    'mod_created' => array(
-        'handlerfile' => '/mod/equella/lib.php',
-        'handlerfunction' => 'equella_handle_mod_created',
-        'schedule' => 'instant',
-        'internal' => 1
-    )
+$observers = array(
+   array(
+      'eventname' => 'mod_updated',
+      'callback' => 'equella_handle_mod_updated',
+   ),
+   array(
+      'eventname' => 'mod_created',
+      'callback' => 'equella_handle_mod_created',
+   ),
 );


### PR DESCRIPTION
In this version, db/events.php is updated to use Moodle event API 2 instead of API 1.
