### PR TITLE
Removing embed object resizing to prevent error in Chrome.

### DIFF
--- a/callbackmulti.php
+++ b/callbackmulti.php
@@ -50,8 +50,8 @@ foreach($links as $link) {
         $mod->filename = clean_param($link['filename'], PARAM_FILE);
     }
 
-    if (isset($link['mimetype'])) {
-        $mod->mimetype = clean_param($link['mimetype'], PARAM_TEXT);
+    if (isset($link['mimeType'])) {
+        $mod->mimetype = clean_param($link['mimeType'], PARAM_TEXT);
     } else {
         $mod->mimetype = mimeinfo('type', $mod->url);
     }

--- a/callbackmulti.php
+++ b/callbackmulti.php
@@ -53,7 +53,7 @@ foreach($links as $link) {
     if (isset($link['mimeType'])) {
         $mod->mimetype = clean_param($link['mimeType'], PARAM_TEXT);
     } else {
-        $mod->mimetype = mimeinfo('type', $mod->url);
+        $mod->mimetype = mimeinfo('type', $mod->filename);
     }
 
     if (isset($link['activationUuid'])) {

--- a/externallib.php
+++ b/externallib.php
@@ -91,7 +91,6 @@ class equella_external extends external_api {
     }
     public static function add_item_to_course_parameters() {
         return new external_function_parameters(array(
-
             'user' => new external_value(PARAM_RAW, 'Username'),
             'courseid' => new external_value(PARAM_RAW, 'Course ID'),
             'sectionid' => new external_value(PARAM_RAW, 'Section ID'),
@@ -100,7 +99,10 @@ class equella_external extends external_api {
             'url' => new external_value(PARAM_RAW, 'URL'),
             'title' => new external_value(PARAM_RAW, 'Title'),
             'description' => new external_value(PARAM_RAW, 'Description'),
-            'attachmentUuid' => new external_value(PARAM_RAW, 'Attachment UUID')));
+            'attachmentUuid' => new external_value(PARAM_RAW, 'Attachment UUID'),
+            'filename' => new external_value(PARAM_RAW, 'Filename', VALUE_DEFAULT, null),
+            'mimetype' => new external_value(PARAM_RAW, 'Mimetype', VALUE_DEFAULT, null)
+        ));
     }
     public static function test_connection_parameters() {
         return new external_function_parameters(array(
@@ -486,11 +488,13 @@ class equella_external extends external_api {
      * @param unknown $title
      * @param unknown $description
      * @param unknown $attachmentUuid
+     * @param unknown $filename
+     * @param unknown $mimetype
      * @return array
      */
-    public static function add_item_to_course($username, $courseid, $sectionnum, $itemUuid, $itemVersion, $url, $title, $description, $attachmentUuid) {
+    public static function add_item_to_course($username, $courseid, $sectionnum, $itemUuid, $itemVersion, $url, $title, $description, $attachmentUuid, $filename, $mimetype) {
         global $DB, $USER;
-
+        
         $params = self::validate_parameters(self::add_item_to_course_parameters(), array(
             'user' => $username,
             'courseid' => $courseid,
@@ -500,7 +504,9 @@ class equella_external extends external_api {
             'url' => $url,
             'title' => $title,
             'description' => $description,
-            'attachmentUuid' => $attachmentUuid
+            'attachmentUuid' => $attachmentUuid,
+            'filename' => $filename,
+            'mimetype' => $mimetype
         ));
 
         self::check_modify_permissions($username, $courseid);
@@ -518,7 +524,13 @@ class equella_external extends external_api {
         $eq->url = $url;
         $eq->uuid = $itemUuid;
         $eq->version = $itemVersion;
-        $eq->mimetype = mimeinfo('type', $title);
+        if ($mimetype!=null) {
+            $eq->mimetype = $mimetype;
+        } elseif ($filename!=null) {
+            $eq->mimetype = mimeinfo('type', $filename);
+        } else {
+            $eq->mimetype = mimeinfo('type', $title);
+        }
         if (!empty($attachmentUuid)) {
             $eq->filename = $title;
             $eq->attachmentuuid = $attachmentUuid;

--- a/locallib.php
+++ b/locallib.php
@@ -133,7 +133,7 @@ EOT;
 
         $code = <<<EOT
 <div class="resourcecontent resourcegeneral">
-  <object id="resourceobject" data="$url" width="800" height="600">
+  <object id="resourceobject" data="$url" style="width:100%; min-height:450px">
     $param
     $clicktoopen
   </object>
@@ -142,7 +142,7 @@ EOT;
     }
 
     // the size is hardcoded in the object above intentionally because it is adjusted by the following function on-the-fly
-    $PAGE->requires->js_init_call('M.util.init_maximised_embed', array('resourceobject'), true);
+//    $PAGE->requires->js_init_call('M.util.init_maximised_embed', array('resourceobject'), true);
 
     return $code;
 }


### PR DESCRIPTION
When EQUELLA activity is opened with option 'open in the same window', resizing the embedded EQUELLA resource with
    $PAGE->requires->js_init_call('M.util.init_maximised_embed', array('resourceobject'), true);
will cause error in Chrome.
If the EQUELLA resource is a Youtube video, play button is not working.
If the EQUELAL resource is a file, it will be downloaded twice.

This fix comments out the js_init_call() and hard-coding resource size being 100% width and 450px min-height.
